### PR TITLE
Fix ydn-db#90: traverse() call func parameter even if tree is empty.

### DIFF
--- a/src/ydn/buffer.js
+++ b/src/ydn/buffer.js
@@ -123,6 +123,7 @@ ydn.structs.Buffer.prototype.traverse = function(func, opt_startValue) {
 ydn.structs.Buffer.prototype.reverseTraverse = function(func, opt_startValue) {
   // If our tree is empty, return immediately
   if (!this.root_) {
+    func();
     return;
   }
 
@@ -144,6 +145,7 @@ ydn.structs.Buffer.prototype.reverseTraverse = function(func, opt_startValue) {
       return retNode; // If null, we'll stop traversing the tree
     }, this));
     if (!startNode) {
+      func();
       return;
     }
   } else {

--- a/src/ydn/buffer.js
+++ b/src/ydn/buffer.js
@@ -58,6 +58,7 @@ goog.inherits(ydn.structs.Buffer, goog.structs.AvlTree);
 ydn.structs.Buffer.prototype.traverse = function(func, opt_startValue) {
   // If our tree is empty, return immediately
   if (!this.root_) {
+    func(null);
     return;
   }
 
@@ -79,6 +80,7 @@ ydn.structs.Buffer.prototype.traverse = function(func, opt_startValue) {
       return retNode; // If null, we'll stop traversing the tree
     });
     if (!startNode) {
+      func(null);
       return;
     }
   } else {
@@ -123,7 +125,7 @@ ydn.structs.Buffer.prototype.traverse = function(func, opt_startValue) {
 ydn.structs.Buffer.prototype.reverseTraverse = function(func, opt_startValue) {
   // If our tree is empty, return immediately
   if (!this.root_) {
-    func();
+    func(null);
     return;
   }
 
@@ -145,7 +147,7 @@ ydn.structs.Buffer.prototype.reverseTraverse = function(func, opt_startValue) {
       return retNode; // If null, we'll stop traversing the tree
     }, this));
     if (!startNode) {
-      func();
+      func(null);
       return;
     }
   } else {


### PR DESCRIPTION
In traverse, and reverse Traverse methods, on an empty tree, or if there is no node with value >= to the start value, the func parameter is not called.
In the scan method in the same context, func method is called.
In ydn.db.core.req.SimpleCursor, if the func parameter of buffer is not called the onSuccess callback is never called and the result state is never set to 'ready'.
This fix call func function with a null parameter if tree is empty or if there is no node with value >= to the start value.

Calling func with null parameter seems to be the way to go since the last line of traverse is already   "func(null); // let know, no more traversal" So calling func with a null parameter should already be supported and means that there is no result to the request.
